### PR TITLE
refactor to move Spotify API call to backend

### DIFF
--- a/SpotifyAPI/_getResults.js
+++ b/SpotifyAPI/_getResults.js
@@ -1,18 +1,22 @@
+const axios = require('axios');
 const _getToken = require('./_getToken');
 
 const _getResults = async query => {
-
-  const limit = 10;
-  
   const token = await _getToken();
+  return new Promise((resolve, reject) => {
+      axios(`https://api.spotify.com/v1/search?q=${query}&type=album&market=US&limit=2`, {
+        method: 'GET',
+        headers: { 'Authorization' : 'Bearer ' + token }
+      })
+      .then(albumResponse => {
+        resolve(albumResponse);
+      })
+      .catch(error => {
+        console.error('error', error);
+        reject(error)
+      });
+    });
+  }
 
-  const result = await fetch(`https://api.spotify.com/v1/search?q=${query}&type=album&market=US&limit=${limit}`, {
-    method: 'GET',
-    headers: { 'Authorization' : 'Bearer ' + token }
-  });
-  
-  const data = await result.json();
-  return data;
-};
 
 module.exports = _getResults;

--- a/SpotifyAPI/_getToken.js
+++ b/SpotifyAPI/_getToken.js
@@ -1,19 +1,27 @@
+const axios = require('axios');
+require('dotenv').config();
+
 const clientId = '2f212092437640b08c1577de2c87a6b3';
 const clientSecret = process.env.CLIENT_SECRET;
 
 const _getToken = async () => {
-
-  const result = await fetch('https://accounts.spotify.com/api/token', {
-    method: 'POST',
-    headers: {
-      'Content-Type' : 'application/x-www-form-urlencoded',
-      'Authorization' : 'Basic ' + Buffer.from( clientId + ':' + clientSecret, 'base64')
-    },
-    body: 'grant_type=client_credentials'
-  });
-
-  const data = await result.json();
-  return data.access_token;
+  return new Promise ((resolve, reject) => {
+    axios('https://accounts.spotify.com/api/token', {
+      headers: {
+        'Content-Type' : 'application/x-www-form-urlencoded',
+        'Authorization' : 'Basic ' + btoa(`${clientId}:${clientSecret}`)
+      },
+      data: 'grant_type=client_credentials',
+      method: 'POST'
+    })
+    .then(tokenResponse => {
+      resolve(tokenResponse.data.access_token)
+    })
+    .catch(error => {
+      console.error('error', error);
+      reject(error)
+    })
+  })
 }
 
 module.exports = _getToken;

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const app = express();
 const cors = require('cors');
 const logger = require('morgan');
+const _getResults = require('./SpotifyAPI/_getResults');
 
 const port = process.env.PORT || 4000;
 
@@ -11,15 +12,33 @@ app.use(logger('dev'));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 
-/* === Routes === */
-app.get('/', (req, res) => {
-  res.status(200).send('Hello Clever Programmer')
-  console.log(req.body);
-})
 
-// app.post('/', (req, res) => {
-//   console.log(req.body);
-// })
+
+
+/* === Routes === */
+// app.get('/', (req, res) => {
+//   console.log('this is happening');
+// });
+
+app.post('/', async (req, res, next) => {
+  try {
+    const query = await req.body.query;
+
+    if (!query) {
+      const albums = null;
+      return res.send(albums);
+    }
+
+    console.log('searching for: ', query)
+    const albumList = await _getResults(query);
+    const albums = await albumList.data.albums.items
+    
+    return res.send(albums);
+  } catch (error) {
+    console.log(error);
+    next();
+  }
+});
 
 app.listen(port, () => {
   console.log('Listening on port:', port);


### PR DESCRIPTION
completely refactored spotify API call to originate from backend to protect client_secret, obtained new secret, added post route that delivers proper album context back to frontend, separated spotify token request out into it's own function, created function that obtains search results